### PR TITLE
Bump Litho version 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Inspiration: http://www.jayrambhia.com/blog/android-litho-gifs
 
 Add the following dependency on your app's `build.gradle`:
 ```
-compile 'com.github.pavlospt:litho-glide:1.4'
+compile 'com.github.pavlospt:litho-glide:1.5'
 ```
 
 Add GlideImage component on your own Component :) 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,9 +26,9 @@ dependencies {
 
   // Litho
   implementation 'com.facebook.soloader:soloader:0.2.0'
-  implementation 'com.facebook.litho:litho-widget:0.13.1'
-  implementation 'com.facebook.litho:litho-annotations:0.13.1'
-  implementation 'com.facebook.litho:litho-core:0.13.1'
-  annotationProcessor 'com.facebook.litho:litho-processor:0.13.1'
+  implementation 'com.facebook.litho:litho-widget:0.20.0'
+  implementation 'com.facebook.litho:litho-annotations:0.20.0'
+  implementation 'com.facebook.litho:litho-core:0.20.0'
+  annotationProcessor 'com.facebook.litho:litho-processor:0.20.0'
   implementation project(':litho-glide')
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-  compileSdkVersion 27
-  buildToolsVersion "27.0.3"
+  compileSdkVersion 28
+
   defaultConfig {
     applicationId "com.github.pavlospt.litho_glide_component_sample"
     minSdkVersion 15
-    targetSdkVersion 27
+    targetSdkVersion 28
     versionCode 1
     versionName "1.0"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -21,11 +21,11 @@ android {
 
 dependencies {
   //noinspection GradleCompatible
-  implementation 'com.android.support:appcompat-v7:27.1.0'
-  implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+  implementation 'com.android.support:appcompat-v7:28.0.0'
+  implementation 'com.android.support.constraint:constraint-layout:1.1.3'
 
   // Litho
-  implementation 'com.facebook.soloader:soloader:0.2.0'
+  implementation 'com.facebook.soloader:soloader:0.5.1'
   implementation 'com.facebook.litho:litho-widget:0.20.0'
   implementation 'com.facebook.litho:litho-annotations:0.20.0'
   implementation 'com.facebook.litho:litho-core:0.20.0'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     google()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.1.0'
+    classpath 'com.android.tools.build:gradle:3.2.0'
 
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-VERSION_NAME=1.4
-VERSION_CODE=5
+VERSION_NAME=1.5
+VERSION_CODE=6
 GROUP=com.github.pavlospt
 
 POM_DESCRIPTION=Glide image loading Component for Litho

--- a/litho-glide/build.gradle
+++ b/litho-glide/build.gradle
@@ -15,14 +15,13 @@ android {
 tasks.withType(Javadoc).all { enabled = false }
 
 dependencies {
-  implementation 'com.facebook.litho:litho-annotations:0.13.1'
-  implementation 'com.facebook.litho:litho-core:0.13.1'
+  implementation 'com.facebook.litho:litho-annotations:0.20.0'
+  implementation 'com.facebook.litho:litho-core:0.20.0'
+  annotationProcessor 'com.facebook.litho:litho-processor:0.20.0'
 
   implementation 'com.github.bumptech.glide:glide:3.8.0'
   //noinspection GradleCompatible
-  implementation 'com.android.support:support-fragment:27.1.0'
-
-  annotationProcessor 'com.facebook.litho:litho-processor:0.13.1'
+  implementation 'com.android.support:support-fragment:27.1.1'
 }
 
 ext {

--- a/litho-glide/build.gradle
+++ b/litho-glide/build.gradle
@@ -7,8 +7,8 @@ android {
   defaultConfig {
     minSdkVersion 15
     targetSdkVersion 27
-    versionCode 5
-    versionName "1.4"
+    versionCode 6
+    versionName "1.5"
   }
 }
 
@@ -27,7 +27,7 @@ dependencies {
 ext {
   PUBLISH_GROUP_ID = 'com.github.pavlospt'
   PUBLISH_ARTIFACT_ID = 'litho-glide'
-  PUBLISH_VERSION = '1.4'
+  PUBLISH_VERSION = '1.5'
 }
 
 //apply from: 'https://raw.githubusercontent.com/ArthurHub/release-android-library/master/android-release-aar.gradle'

--- a/litho-glide/build.gradle
+++ b/litho-glide/build.gradle
@@ -1,12 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-  compileSdkVersion 27
-  buildToolsVersion "27.0.3"
+  compileSdkVersion 28
 
   defaultConfig {
     minSdkVersion 15
-    targetSdkVersion 27
+    targetSdkVersion 28
     versionCode 6
     versionName "1.5"
   }
@@ -21,7 +20,7 @@ dependencies {
 
   implementation 'com.github.bumptech.glide:glide:3.8.0'
   //noinspection GradleCompatible
-  implementation 'com.android.support:support-fragment:27.1.1'
+  implementation 'com.android.support:support-fragment:28.0.0'
 }
 
 ext {

--- a/litho-glide/src/main/java/com/github/pavlospt/litho/glide/GlideImageSpec.java
+++ b/litho-glide/src/main/java/com/github/pavlospt/litho/glide/GlideImageSpec.java
@@ -1,5 +1,6 @@
 package com.github.pavlospt.litho.glide;
 
+import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.widget.ImageView;
@@ -24,7 +25,6 @@ import com.facebook.litho.utils.MeasureUtils;
 import java.io.File;
 
 import static com.facebook.litho.annotations.ResType.DRAWABLE;
-import static com.facebook.litho.annotations.ResType.INT;
 
 @MountSpec
 public class GlideImageSpec {
@@ -45,8 +45,8 @@ public class GlideImageSpec {
   }
 
   @OnCreateMountContent
-  static ImageView onCreateMountContent(ComponentContext c) {
-    return new ImageView(c.getBaseContext());
+  static ImageView onCreateMountContent(Context c) {
+    return new ImageView(c);
   }
 
   @OnMount


### PR DESCRIPTION
This PR includes:

* Litho version bump to `0.20.0`
* SoLoader version bump to `0.5.1`
* Compile SDK version bump to `28`
* Target SDK version bump to `28`
* AGP version bump to `3.2.0`
* New version of library `1.5`

Probably closes https://github.com/pavlospt/litho-glide/issues/5 